### PR TITLE
- Stripe Android SDK 10.4.6 rejected by google play store compliance

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -70,6 +70,6 @@ android {
 dependencies {
     api 'org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.70'
     implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'com.stripe:stripe-android:10.4.6'
+    implementation 'com.stripe:stripe-android:10.5.0'
     implementation 'com.google.android.gms:play-services-wallet:18.0.0'
 }


### PR DESCRIPTION
- stripe_payment package fix only available for flutter 2 versions
- bump stripe android gradle hotfix version on 1.0.7 revision
- https://github.com/jonasbark/flutter_stripe_payment/issues/301
- https://github.com/stripe/stripe-android/issues/3864